### PR TITLE
Add FS(Must)?(Byte|String) helper functions.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -24,7 +24,7 @@ After producing an output file, the assets may be accessed with the FS()
 function, which takes a flag to use local assets instead (for local
 development).
 
-FS(Must)?(Byte|String) return an asset as a (byte slice|string).
+FS(Must)?(Byte|String) returns an asset as a (byte slice|string).
 FSMust(Byte|String) panics if the asset is not found.
 
 */

--- a/doc.go
+++ b/doc.go
@@ -24,8 +24,8 @@ After producing an output file, the assets may be accessed with the FS()
 function, which takes a flag to use local assets instead (for local
 development).
 
-FSString(useLocal bool, path string) and FSByte(useLocal bool, path string) return
-an asset as a byte slice or a string, respectively.
+FS(Must)?(Byte|String) return an asset as a (byte slice|string).
+FSMust(Byte|String) panics if the asset is not found.
 
 */
 package main

--- a/doc.go
+++ b/doc.go
@@ -24,5 +24,8 @@ After producing an output file, the assets may be accessed with the FS()
 function, which takes a flag to use local assets instead (for local
 development).
 
+FSString(useLocal bool, path string) and FSByte(useLocal bool, path string) return
+an asset as a byte slice or a string, respectively.
+
 */
 package main

--- a/main.go
+++ b/main.go
@@ -256,7 +256,7 @@ func FSByte(useLocal bool, path string) ([]byte, error) {
 	return ioutil.ReadAll(r)
 }
 
-// FSMustByte is same as FSByte but panics on error.
+// FSMustByte is the same as FSByte but panics on error.
 func FSMustByte(useLocal bool, path string) []byte {
 	if b, err := FSByte(useLocal, path); err != nil {
 		panic(err)
@@ -271,7 +271,7 @@ func FSString(useLocal bool, path string) (string, error) {
 	return string(b), e
 }
 
-// FSMustString is same as FSString but panics on error.
+// FSMustString is the same as FSString but panics on error.
 func FSMustString(useLocal bool, path string) string {
 	return string(FSMustByte(useLocal, path))
 }

--- a/main.go
+++ b/main.go
@@ -273,11 +273,7 @@ func FSString(useLocal bool, path string) (string, error) {
 
 // FSMustString is same as FSString but panics on error.
 func FSMustString(useLocal bool, path string) string {
-	if s, err := FSString(useLocal, path); err != nil {
-		panic(err)
-	} else {
-		return s
-	}
+	return string(FSMustByte(useLocal, path))
 }
 
 var _esc_data = map[string]*_esc_file{

--- a/main.go
+++ b/main.go
@@ -247,6 +247,39 @@ func FS(useLocal bool) http.FileSystem {
 	return _esc_static
 }
 
+// FSByte returns the content of an embedded asset as a byte slice.
+func FSByte(useLocal bool, path string) ([]byte, error) {
+	r, err := FS(useLocal).Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadAll(r)
+}
+
+// FSMustByte is same as FSByte but panics on error.
+func FSMustByte(useLocal bool, path string) []byte {
+	if b, err := FSByte(useLocal, path); err != nil {
+		panic(err)
+	} else {
+		return b
+	}
+}
+
+// FSString returns the content of an embeded asset as a string.
+func FSString(useLocal bool, path string) (string, error) {
+	b, e := FSByte(useLocal, path)
+	return string(b), e
+}
+
+// FSMustString is same as FSString but panics on error.
+func FSMustString(useLocal bool, path string) string {
+	if s, err := FSString(useLocal, path); err != nil {
+		panic(err)
+	} else {
+		return s
+	}
+}
+
 var _esc_data = map[string]*_esc_file{
 `
 	footer = `}


### PR DESCRIPTION
Hi Matt,

I like `esc` better than all the alternatives, and here are some helper functions to get assets directly.

Use case: storing more complex templates in external files that are going to be embedded, e.g.

```go
pageTemplateStr := FSMustString(false, "/page.html")
pageTemplate = template.Must(template.New("page").Parse(pageTemplateStr))
```

If you don't like the names, feel free to change to whatever you think is best.