### PR TITLE
Remove underscores from variable names to conform to golint style guide

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ var (
 	flagPrefix = flag.String("prefix", "", "Prefix to strip from filesnames.")
 )
 
-type _esc_file struct {
+type escFile struct {
 	data  []byte
 	local string
 }
@@ -29,7 +29,7 @@ func main() {
 	flag.Parse()
 	var err error
 	var fnames, dirnames []string
-	content := make(map[string]_esc_file)
+	content := make(map[string]escFile)
 	prefix := filepath.ToSlash(*flagPrefix)
 	for _, base := range flag.Args() {
 		files := []string{base}
@@ -60,7 +60,7 @@ func main() {
 				fpath := filepath.ToSlash(fname)
 				n := strings.TrimPrefix(fpath, prefix)
 				n = path.Join("/", n)
-				content[n] = _esc_file{data: b, local: fpath}
+				content[n] = escFile{data: b, local: fpath}
 				fnames = append(fnames, n)
 			}
 			f.Close()
@@ -140,15 +140,15 @@ import (
 	"time"
 )
 
-type _esc_localFS struct{}
+type escLocalFS struct{}
 
-var _esc_local _esc_localFS
+var escLocal escLocalFS
 
-type _esc_staticFS struct{}
+type escStaticFS struct{}
 
-var _esc_static _esc_staticFS
+var escStatic escStaticFS
 
-type _esc_file struct {
+type escFile struct {
 	compressed string
 	size       int64
 	local      string
@@ -159,16 +159,16 @@ type _esc_file struct {
 	name string
 }
 
-func (_esc_localFS) Open(name string) (http.File, error) {
-	f, present := _esc_data[path.Clean(name)]
+func (escLocalFS) Open(name string) (http.File, error) {
+	f, present := escData[path.Clean(name)]
 	if !present {
 		return nil, os.ErrNotExist
 	}
 	return os.Open(f.local)
 }
 
-func (_esc_staticFS) prepare(name string) (*_esc_file, error) {
-	f, present := _esc_data[path.Clean(name)]
+func (escStaticFS) prepare(name string) (*escFile, error) {
+	f, present := escData[path.Clean(name)]
 	if !present {
 		return nil, os.ErrNotExist
 	}
@@ -191,7 +191,7 @@ func (_esc_staticFS) prepare(name string) (*_esc_file, error) {
 	return f, nil
 }
 
-func (fs _esc_staticFS) Open(name string) (http.File, error) {
+func (fs escStaticFS) Open(name string) (http.File, error) {
 	f, err := fs.prepare(name)
 	if err != nil {
 		return nil, err
@@ -199,50 +199,50 @@ func (fs _esc_staticFS) Open(name string) (http.File, error) {
 	return f.File()
 }
 
-func (f *_esc_file) File() (http.File, error) {
+func (f *escFile) File() (http.File, error) {
 	type httpFile struct {
 		*bytes.Reader
-		*_esc_file
+		*escFile
 	}
 	return &httpFile{
-		Reader:    bytes.NewReader(f.data),
-		_esc_file: f,
+		Reader:  bytes.NewReader(f.data),
+		escFile: f,
 	}, nil
 }
 
-func (f *_esc_file) Close() error {
+func (f *escFile) Close() error {
 	return nil
 }
 
-func (f *_esc_file) Readdir(count int) ([]os.FileInfo, error) {
+func (f *escFile) Readdir(count int) ([]os.FileInfo, error) {
 	return nil, nil
 }
 
-func (f *_esc_file) Stat() (os.FileInfo, error) {
+func (f *escFile) Stat() (os.FileInfo, error) {
 	return f, nil
 }
 
-func (f *_esc_file) Name() string {
+func (f *escFile) Name() string {
 	return f.name
 }
 
-func (f *_esc_file) Size() int64 {
+func (f *escFile) Size() int64 {
 	return f.size
 }
 
-func (f *_esc_file) Mode() os.FileMode {
+func (f *escFile) Mode() os.FileMode {
 	return 0
 }
 
-func (f *_esc_file) ModTime() time.Time {
+func (f *escFile) ModTime() time.Time {
 	return time.Time{}
 }
 
-func (f *_esc_file) IsDir() bool {
+func (f *escFile) IsDir() bool {
 	return f.isDir
 }
 
-func (f *_esc_file) Sys() interface{} {
+func (f *escFile) Sys() interface{} {
 	return f
 }
 
@@ -250,22 +250,22 @@ func (f *_esc_file) Sys() interface{} {
 // the filesystem's contents are instead used.
 func FS(useLocal bool) http.FileSystem {
 	if useLocal {
-		return _esc_local
+		return escLocal
 	}
-	return _esc_static
+	return escStatic
 }
 
 // FSByte returns the named file from the embedded assets. If useLocal is
 // true, the filesystem's contents are instead used.
 func FSByte(useLocal bool, name string) ([]byte, error) {
 	if useLocal {
-		f, err := _esc_local.Open(name)
+		f, err := escLocal.Open(name)
 		if err != nil {
 			return nil, err
 		}
 		return ioutil.ReadAll(f)
 	}
-	f, err := _esc_static.prepare(name)
+	f, err := escStatic.prepare(name)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func FSMustString(useLocal bool, name string) string {
 	return string(FSMustByte(useLocal, name))
 }
 
-var _esc_data = map[string]*_esc_file{
+var escData = map[string]*escFile{
 `
 	footer = `}
 `


### PR DESCRIPTION
PR to fix [Issue #9: generated code do not satisfy go lint](https://github.com/mjibson/esc/issues/9)