### PR TITLE
Remove static checking for local files

### DIFF
--- a/main.go
+++ b/main.go
@@ -197,11 +197,7 @@ type _escFile struct {
 }
 
 func (_escLocalFS) Open(name string) (http.File, error) {
-	f, present := _escData[path.Clean(name)]
-	if !present {
-		return nil, os.ErrNotExist
-	}
-	return os.Open(f.local)
+	return os.Open(path.Clean(name)[1:])
 }
 
 func (_escStaticFS) prepare(name string) (*_escFile, error) {


### PR DESCRIPTION
You don't need to check if file exists in static before using local files. Saves recompiling effort when you add a new file.