### PR TITLE
Maximize efficient alignment of _escFile.

### DIFF
--- a/main.go
+++ b/main.go
@@ -225,8 +225,8 @@ type _escFile struct {
 	local      string
 	isDir      bool
 
-	data []byte
 	once sync.Once
+	data []byte
 	name string
 }
 


### PR DESCRIPTION
From aligncheck: struct _escFile could have size 104 (currently 112).