### PR TITLE
Strip leading / from local path of directories

### DIFF
--- a/embed/embed.go
+++ b/embed/embed.go
@@ -166,6 +166,11 @@ func Run(conf *Config) {
 		if len(local) == 0 {
 			local = "."
 		}
+		if local[0] == '/' {
+			// Read dirs relative to the go proc's cwd vs system's
+			// fs root.
+			local = local[1:]
+		}
 		fmt.Fprintf(w, `
 	%q: {
 		isDir: true,


### PR DESCRIPTION
Was reading system's filesystem root for directories instead of go
proc's cwd.   Bug was evidenced by "get /"  not being translated get
/index.html and also If you look at the generated static.go (or
whatever) file, all directories have 'local' starting with /.

Closes #24