### PR TITLE
Quick and dirty implementation of Readdir for staticFS

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 
-	"github.com/mjibson/esc/embed"
+	"github.com/danielskowronski/esc/embed"
 )
 
 func main() {


### PR DESCRIPTION
Quickly written replacement of `return nil, nil`. 

Some apps require filesystem to enumerate files in directory, only option for http.FileSystem is via `Readdir` which was left unimplemented. With array of strings (filenames) in structure `_escData` prepared at generation time we can later execute `Open().Stat()` to return data in form expected from normal `Readdir`. 

For now error handling is skipped (since all files were already opened and parsed probably nothing bad should happen).