### PR TITLE
esc package imports embed locally

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/mjibson/esc/embed"
+	"./embed"
 )
 
 func main() {


### PR DESCRIPTION
I see the reasoning behind this commit
https://github.com/mjibson/esc/commit/ce63115657a87bf5a798fb557e2db659742e509a#diff-7ddfb3e035b42cd70649cc33393fe32cR6

and all the ways it's used so far
https://github.com/search?q=%22github.com%2Fmjibson%2Fesc%2Fembed%22&type=Code&utf8=%E2%9C%93

But I figured for the base `esc` package, it made sense to import locally rather than with the github URL.  This allows me to `go run` the `esc/main.go` package in some `//go:generate` commands where I've vendored `esc` ... Otherwise it complains about not finding `esc` in any of my path/bin ... which kinda breaks the spirit of vendoring in my use case.

Didn't seem like this change would preclude others from using ...`esc/embed` as a library on its own, but I could be wrong.