### PR TITLE
Avoid unnecessary conversion and so pass with unconvert linter

### DIFF
--- a/embed/embed.go
+++ b/embed/embed.go
@@ -364,7 +364,7 @@ func (f *_escFile) Readdir(count int) ([]os.FileInfo, error) {
 		return nil, io.EOF
 	}
 
-	return []os.FileInfo(fis[0:limit]), nil
+	return fis[0:limit], nil
 }
 
 

--- a/testdata/empty.expect
+++ b/testdata/empty.expect
@@ -119,7 +119,7 @@ func (f *_escFile) Readdir(count int) ([]os.FileInfo, error) {
 		return nil, io.EOF
 	}
 
-	return []os.FileInfo(fis[0:limit]), nil
+	return fis[0:limit], nil
 }
 
 func (f *_escFile) Stat() (os.FileInfo, error) {


### PR DESCRIPTION
Signed-off-by: Maxime Soulé <btik-git@scoubidou.com>